### PR TITLE
[fix] #24 - API 로드 방식 개선 및 중복 실행 방지

### DIFF
--- a/src/assets/naver-map/script.js
+++ b/src/assets/naver-map/script.js
@@ -1,20 +1,39 @@
+let scriptLoaded = false // map API 로드 여부
+
 document.addEventListener("DOMContentLoaded", function () {
 
     // iframe이 동적으로 추가될 때까지 기다리기
     let observer = new MutationObserver(() => {
         const iframe = document.getElementById("map-iframe")
-        if (iframe) {
-            observer.disconnect() // iframe을 찾았으면 MutationObserver 해제
+        const mapElement = document.getElementById("map")
+
+        if (iframe && mapElement && !scriptLoaded) { // 이미 로드된 경우 실행 방지
+            observer.disconnect() // iframe과 map 요소를 찾았으면 MutationObserver 해제
+            loadMapScript() // map API 로드
         }
     })
 
     // body에 MutationObserver 적용
     observer.observe(document.body, { childList: true, subtree: true })
 
-    //API로 clientId 가져오기
-    fetch("http://localhost:3000/api/client-id")
+     // 처음부터 #map이 존재하는 경우 즉시 실행
+     if (document.getElementById("map") && !scriptLoaded) {
+        loadMapScript()
+    }
+})
+
+// 네이버 지도 API 로드 및 initMap 실행
+function loadMapScript() {
+    if (scriptLoaded) {
+        return // 중복 요청 방지
+    }
+
+    scriptLoaded = true // 중복 실행 방지
+
+    fetch("http://localhost:3000/api/maps/client-id")
         .then((response) => response.json())
         .then((data) => {
+
             // 네이버 지도 API 동적 로드
             const script = document.createElement("script")
             script.src = `https://oapi.map.naver.com/openapi/v3/maps.js?ncpClientId=${data.clientId}`
@@ -24,7 +43,7 @@ document.addEventListener("DOMContentLoaded", function () {
             document.body.appendChild(script)
         })
         .catch((error) => console.error("Error fetching client ID:", error))
-})
+}
 
 const mapConfig = {
     map: null,


### PR DESCRIPTION
<!-- 제목은 [태그] #이슈번호 - 작업내용 요약 형식으로 작성해주세요 -->
### Issue
closed #24 
<br/>


## 작업 내용
- MutationObserver를 활용하여 iframe과 #map 요소 감지 후 loadMapScript() 실행
- loadMapScript() 중복 실행 방지를 위해 scriptLoaded 플래그를 추가하여 한 번만 실행되도록 수정
- ERR_NETWORK_CHANGED 오류 발생 방지를 위해 중복 요청이 발생하지 않도록 개선

## 체크리스트
- [x] 기능이 정상적으로 동작하는지 확인
- http://localhost:3000/api/maps/client-id 호출 시응답이 정상적으로 반환되는지 확인
- map API script가 정상적으로 로드되는지 확인
- map API가 중복 로드되지 않는지 확인
- #map 요소가 동적으로 추가될 때 MutationObserver가 감지하는지 확인
- #map 요소가 감지된 후 loadMapScript()가 한 번만 실행되는지 확인
- #map 요소가 처음부터 존재할 때도 정상적으로 동작하는지 확인
- [x] 기존 코드에 영향을 주지 않는지 확인

## 기타 사항
- 
