### PR TITLE
[feat] #26 - 검색창 및 하단메뉴바 공통 컴포넌트 추가

### DIFF
--- a/src/app/model/common/common.module.ts
+++ b/src/app/model/common/common.module.ts
@@ -1,0 +1,23 @@
+import { NgModule } from '@angular/core'
+import { CommonModule } from '@angular/common'
+import { FormsModule } from '@angular/forms'
+import { SearchBarComponent } from './components/search-bar/search-bar.component'
+import { FooterMenuComponent } from './components/footer-menu/footer-menu.component'
+import { IonicModule } from '@ionic/angular'
+
+@NgModule({
+  declarations: [
+    SearchBarComponent,
+    FooterMenuComponent 
+  ],
+  imports: [
+    CommonModule,
+    FormsModule,
+    IonicModule
+  ],
+  exports: [
+    SearchBarComponent,
+    FooterMenuComponent
+  ]
+})
+export class CommonComponentsModule {}

--- a/src/app/model/common/components/footer-menu/footer-menu.component.html
+++ b/src/app/model/common/components/footer-menu/footer-menu.component.html
@@ -1,0 +1,20 @@
+<ion-footer>
+    <ion-toolbar>
+      <ion-grid>
+        <ion-row class="ion-justify-content-around ion-align-items-center">
+          <ion-col class="ion-text-center">
+            <ion-icon name="home-outline" size="large"></ion-icon>
+          </ion-col>
+          <ion-col class="ion-text-center">
+            <ion-icon name="gift-outline" size="large"></ion-icon>
+          </ion-col>
+          <ion-col class="ion-text-center">
+            <ion-icon name="chatbubble-outline" size="large"></ion-icon>
+          </ion-col>
+          <ion-col class="ion-text-center">
+            <ion-icon name="trophy-outline" size="large"></ion-icon>
+          </ion-col>
+        </ion-row>
+      </ion-grid>
+    </ion-toolbar>
+  </ion-footer>

--- a/src/app/model/common/components/footer-menu/footer-menu.component.scss
+++ b/src/app/model/common/components/footer-menu/footer-menu.component.scss
@@ -1,0 +1,21 @@
+ion-footer {
+    background-color: white;
+    border-top: 1px solid #ccc;
+    height: 70px;
+}
+
+ion-toolbar {
+    height: 100%; // 툴바가 footer 높이를 가득 채우도록 설정
+    display: flex;
+    align-items: center; // 아이콘 정렬
+}
+
+ion-icon {
+    color: #555;
+    font-size: 40px; // 아이콘 크기 조정
+    transition: color 0.3s;
+}
+
+ion-icon:hover {
+    color: #0078ff;
+}

--- a/src/app/model/common/components/footer-menu/footer-menu.component.ts
+++ b/src/app/model/common/components/footer-menu/footer-menu.component.ts
@@ -1,0 +1,9 @@
+import { Component } from '@angular/core'
+
+@Component({
+  selector: 'app-footer-menu',
+  templateUrl: './footer-menu.component.html',
+  styleUrls: ['./footer-menu.component.scss'],
+  standalone: false
+})
+export class FooterMenuComponent {}

--- a/src/app/model/common/components/search-bar/search-bar.component.html
+++ b/src/app/model/common/components/search-bar/search-bar.component.html
@@ -1,0 +1,14 @@
+<!----------------------------------------------------
+* ion-searchbar를 사용하여 검색 입력을 받음
+- [(ngModel)]을 사용하여 양방향 데이터 바인딩 적용
+- (ionInput) 이벤트를 사용하여 사용자가 입력할 때 검색 실행
+- showCancelButton="focus" → 입력할 때 취소 버튼 표시
+- debounce="500" → 0.5초마다 입력된 값 검색 
+----------------------------------------------------->
+<ion-searchbar
+  [(ngModel)]="searchQuery" 
+  (ionInput)="search()"
+  placeholder="가게명 검색"
+  showCancelButton="focus"
+  debounce="500" 
+></ion-searchbar>

--- a/src/app/model/common/components/search-bar/search-bar.component.scss
+++ b/src/app/model/common/components/search-bar/search-bar.component.scss
@@ -1,0 +1,9 @@
+ion-searchbar {
+    --background: white; // 배경색
+    --border-radius: 8px; // 모서리 둥글기
+    --box-shadow: 0 2px 8px rgba(0, 0, 0, 0.2); // 그림자 효과
+    --placeholder-color: #999; // 플레이스홀더 색상
+    --icon-color: #0078ff; // 검색 아이콘 색상
+    width: 100%; // 전체 너비 설정
+    padding: 10px;
+}

--- a/src/app/model/common/components/search-bar/search-bar.component.ts
+++ b/src/app/model/common/components/search-bar/search-bar.component.ts
@@ -1,0 +1,17 @@
+import { Component, EventEmitter, Output } from '@angular/core'
+
+@Component({
+    selector: 'app-search-bar',
+    templateUrl: './search-bar.component.html',
+    styleUrls: ['./search-bar.component.scss'],
+    standalone: false
+})
+export class SearchBarComponent {
+    searchQuery: string = ''
+
+    @Output() searchEvent = new EventEmitter<string>()
+
+    search() {
+        this.searchEvent.emit(this.searchQuery)
+    }
+}


### PR DESCRIPTION
<!-- 제목은 [태그] #이슈번호 - 작업내용 요약 형식으로 작성해주세요 -->
### Issue
closed #26 
<br/>


## 작업 내용
- 검색창(search-bar.component)을 공통 컴포넌트로 분리
- 하단 메뉴바(footer-menu.component)를 공통 컴포넌트로 분리
- common.module.ts에 공통 컴포넌트 등록하여 재사용 가능하도록 설정
- ion-searchbar를 적용하여 검색창 UI 개선

## 체크리스트
- [x] 기능이 정상적으로 동작하는지 확인
- app-search-bar와 app-footer-menu가 정상적으로 동작하는지 확인
- 기존 개별 구현된 검색창 및 하단 메뉴가 정상적으로 대체되었는지 확인
- common.module.ts에 공통 컴포넌트가 올바르게 등록되었는지 확인
- [x] 기존 코드에 영향을 주지 않는지 확인

## 기타 사항
- 참고 자료 (결과물 사진 등)

- 파일 경로
![image](https://github.com/user-attachments/assets/30824459-1f01-4344-8c5e-be2d74b6a80e)

- 적용 이미지 참고
![image](https://github.com/user-attachments/assets/9f413540-f826-4dc0-9fe3-4d793b47b3fb)



