### PR TITLE
[feat] #62 - JWT / 로그인 유지 / 로그아웃 관련 추가 기능 구현

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -1,4 +1,4 @@
-import { provideHttpClient } from '@angular/common/http'
+import { provideHttpClient, withInterceptorsFromDi } from '@angular/common/http'
 import { NgModule } from '@angular/core'
 import { BrowserModule } from '@angular/platform-browser'
 import { RouteReuseStrategy } from '@angular/router'
@@ -21,14 +21,14 @@ import { SharedModule } from './shared/module/shared.module'
     ReviewsModule,
     AdminModule,
     FormsModule,
-    SharedModule
+    SharedModule,
   ],
   providers: [
     {
       provide: RouteReuseStrategy,
       useClass: IonicRouteStrategy
     },
-    provideHttpClient(),
+    provideHttpClient(withInterceptorsFromDi())
   ],
   bootstrap: [AppComponent],
 })

--- a/src/app/home/home.page.html
+++ b/src/app/home/home.page.html
@@ -15,6 +15,9 @@
 
   <div id="container">
     <strong>용기종기 메인 화면입니다.</strong>
-    <p>Start with Ionic <a target="_blank" rel="noopener noreferrer" href="https://ionicframework.com/docs/components">UI Components</a></p>
   </div>
+
+  <ion-button expand="block" (click)="signOut()"> 
+    로그아웃
+  </ion-button>
 </ion-content>

--- a/src/app/home/home.page.ts
+++ b/src/app/home/home.page.ts
@@ -1,4 +1,6 @@
 import { Component } from '@angular/core'
+import { AuthService } from '../shared/services/auth.service'
+import { ActivatedRoute, Router } from '@angular/router'
 
 @Component({
   selector: 'app-home',
@@ -8,6 +10,13 @@ import { Component } from '@angular/core'
 })
 export class HomePage {
 
-  constructor() { }
+  constructor(
+    private authService: AuthService,
+    private router: Router,
+  ) { }
 
+  async signOut() {
+    this.authService.signOut()
+    await this.router.navigate(['/signin'])
+  }
 }

--- a/src/app/home/home.page.ts
+++ b/src/app/home/home.page.ts
@@ -9,6 +9,8 @@ import { ActivatedRoute, Router } from '@angular/router'
   standalone: false,
 })
 export class HomePage {
+  // 로그인 상태 관찰
+  isLoggedIn$ = this.authService.isLoggedIn$
 
   constructor(
     private authService: AuthService,

--- a/src/app/register/register.page.ts
+++ b/src/app/register/register.page.ts
@@ -1,4 +1,4 @@
-import { Component } from '@angular/core'
+import { Component, OnInit } from '@angular/core'
 import { CreateUserDTO } from '../shared/model/auth/create-user.interface'
 import { UserRole } from '../shared/model/users/user-role.enum'
 import { AuthService } from '../shared/services/auth.service'
@@ -10,7 +10,15 @@ import { Router } from '@angular/router'
   templateUrl: './register.page.html',
   standalone: false,
 })
-export class RegisterPage {
+export class RegisterPage implements OnInit {
+  // 로그인 상태면 (token 보유 시) 자동으로 home으로 이동
+  ngOnInit() {
+    const token = localStorage.getItem('accessToken')
+    if (token) {
+      this.router.navigate(['/home'])
+    }
+  }
+
   form: CreateUserDTO = {
     email: '',
     password: '',

--- a/src/app/shared/interceptors/auth.interceptor.ts
+++ b/src/app/shared/interceptors/auth.interceptor.ts
@@ -1,0 +1,18 @@
+import { HttpEvent, HttpHandler, HttpInterceptor, HttpRequest } from "@angular/common/http"
+import { Observable } from "rxjs"
+
+export class AuthInterceptor implements HttpInterceptor {
+    intercept(req: HttpRequest<any>, next: HttpHandler): Observable<HttpEvent<any>> {
+        const token = localStorage.getItem('accessToken')
+
+        if (token) {
+            const clonedReq = req.clone({
+                setHeaders: {
+                    Authorization: `Bearer ${token}`
+                }
+            })
+            return next.handle(clonedReq)
+        }
+        return next.handle(req)
+    }
+}

--- a/src/app/shared/module/shared.module.ts
+++ b/src/app/shared/module/shared.module.ts
@@ -8,6 +8,8 @@ import { EventStatusPipe } from '../pipes/event-status.pipe'
 import { CategoryPipe } from '../pipes/category.pipe'
 import { KoreanDatePipe } from '../pipes/koreanDate.pipe'
 import { RequestStatusPipe } from '../pipes/request-status.pipe'
+import { HTTP_INTERCEPTORS } from '@angular/common/http'
+import { AuthInterceptor } from '../interceptors/auth.interceptor'
 
 @NgModule({
   declarations: [
@@ -30,6 +32,13 @@ import { RequestStatusPipe } from '../pipes/request-status.pipe'
     CategoryPipe,
     KoreanDatePipe,
     RequestStatusPipe,
+  ],
+  providers: [
+    {
+      provide: HTTP_INTERCEPTORS,
+      useClass: AuthInterceptor,
+      multi: true
+    }
   ]
 })
 export class SharedModule { }

--- a/src/app/shared/services/auth.service.ts
+++ b/src/app/shared/services/auth.service.ts
@@ -1,7 +1,7 @@
 import { HttpClient } from '@angular/common/http'
 import { Injectable } from '@angular/core'
 import { CreateUserDTO } from '../model/auth/create-user.interface'
-import { Observable, tap } from 'rxjs'
+import { BehaviorSubject, Observable, tap } from 'rxjs'
 import { ApiResponseDTO } from '../model/common/api-response.interface'
 import { SignInDTO } from '../model/auth/singin.interface'
 
@@ -10,8 +10,12 @@ import { SignInDTO } from '../model/auth/singin.interface'
 })
 export class AuthService {
   private apiUrl = 'http://localhost:3000/api/auth/'
+  private isLoggedInSubject = new BehaviorSubject<boolean>(!!localStorage.getItem('accessToken'))
 
   constructor(private http: HttpClient) { }
+
+  // 로그인 상태를 구독하는 BehaviorSubject 사용
+  isLoggedIn$ = this.isLoggedInSubject.asObservable()
 
   createUser(createUserDTO: CreateUserDTO): Observable<ApiResponseDTO<void>> {
     return this.http.post<ApiResponseDTO<void>>(`${this.apiUrl}signup`, createUserDTO)
@@ -22,6 +26,7 @@ export class AuthService {
       tap((response) => {
         if (response.success && response.data?.accessToken) {
           localStorage.setItem('accessToken', response.data.accessToken)
+          this.isLoggedInSubject.next(true) // 로그인 상태 변경
         }
       })
     )
@@ -29,5 +34,6 @@ export class AuthService {
 
   signOut(): void {
     localStorage.removeItem('accessToken') // 로그아웃 시 토큰 삭제
+    this.isLoggedInSubject.next(false)
   }
 }

--- a/src/app/shared/services/auth.service.ts
+++ b/src/app/shared/services/auth.service.ts
@@ -1,7 +1,7 @@
 import { HttpClient } from '@angular/common/http'
 import { Injectable } from '@angular/core'
 import { CreateUserDTO } from '../model/auth/create-user.interface'
-import { Observable } from 'rxjs'
+import { Observable, tap } from 'rxjs'
 import { ApiResponseDTO } from '../model/common/api-response.interface'
 import { SignInDTO } from '../model/auth/singin.interface'
 
@@ -17,7 +17,17 @@ export class AuthService {
     return this.http.post<ApiResponseDTO<void>>(`${this.apiUrl}signup`, createUserDTO)
   }
 
-  signIn(signInDTO: SignInDTO): Observable<ApiResponseDTO<void>> {
-    return this.http.post<ApiResponseDTO<void>>(`${this.apiUrl}signin`, signInDTO)
+  signIn(signInDTO: SignInDTO): Observable<ApiResponseDTO<{ accessToken: string }>> {
+    return this.http.post<ApiResponseDTO<{ accessToken: string }>>(`${this.apiUrl}signin`, signInDTO).pipe(
+      tap((response) => {
+        if (response.success && response.data?.accessToken) {
+          localStorage.setItem('accessToken', response.data.accessToken)
+        }
+      })
+    )
+  }
+
+  signOut(): void {
+    localStorage.removeItem('accessToken') // 로그아웃 시 토큰 삭제
   }
 }

--- a/src/app/signin/signin.page.ts
+++ b/src/app/signin/signin.page.ts
@@ -1,4 +1,4 @@
-import { Component } from '@angular/core'
+import { Component, OnInit } from '@angular/core'
 import { SignInDTO } from '../shared/model/auth/singin.interface'
 import { AuthService } from '../shared/services/auth.service'
 import { Router } from '@angular/router'
@@ -8,8 +8,14 @@ import { Router } from '@angular/router'
   templateUrl: './signin.page.html',
   standalone: false
 })
-export class SigninPage {
-  registerPageUrl = 'http://localhost:8100/register'
+export class SigninPage implements OnInit {
+  // 로그인 상태면 (token 보유 시) 자동으로 home으로 이동
+  ngOnInit() {
+    const token = localStorage.getItem('accessToken')
+    if (token) {
+      this.router.navigate(['/home'])
+    }
+  }
 
   form: SignInDTO = {
     email: '',

--- a/src/app/signin/signin.page.ts
+++ b/src/app/signin/signin.page.ts
@@ -9,12 +9,13 @@ import { Router } from '@angular/router'
   standalone: false
 })
 export class SigninPage implements OnInit {
-  // 로그인 상태면 (token 보유 시) 자동으로 home으로 이동
+  // 로그인 상태를 구독, 로그인상태 시 자동으로 홈으로 이동
   ngOnInit() {
-    const token = localStorage.getItem('accessToken')
-    if (token) {
-      this.router.navigate(['/home'])
-    }
+    this.authService.isLoggedIn$.subscribe(isLoggedIn => {
+      if(isLoggedIn) {
+        this.router.navigate(['/home'])
+      }
+    })
   }
 
   form: SignInDTO = {


### PR DESCRIPTION
<!-- 제목은 [태그] #이슈번호 - 작업내용 요약 형식으로 작성해주세요 -->
### Issue
closed #62 
<br/>


## 작업 내용
- JWT토큰을 전달받아 로컬 스토리지(브라우저)에 저장하는 기능
- HTTP interceptor를 통해 모든 API요청 헤더에 자동으로 JWT 토큰을 담는 기능
- BehaviorSubject를 통한 로그인/로그아웃 상태 관리 기능

---
- 로그인 상태가 유지됩니다. 로그인한 유저와 관련된 정보만 출력됩니다.
- 이제 로그아웃 할 수 있습니다. /home에서 로그아웃 가능합니다.
- 이제 로그인 상태에서 /signin 주소로 접속하면 자동으로 /home으로 리다이렉팅됩니다.

## 체크리스트
- [x] 기능이 정상적으로 동작하는지 확인
- [x] 기존 코드에 영향을 주지 않는지 확인

## 기타 사항
- 리뷰어가 알면 좋을 추가적인 내용
- 참고 자료 (결과물 사진 등)
- 피드백 요청
