### PR TITLE
feat: 즐겨찾기 화면 및 기능 구현

### DIFF
--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -43,6 +43,10 @@ const routes: Routes = [
     path: 'register',
     loadChildren: () => import('./register/register.module').then(m => m.RegisterModule)
   },
+  {
+    path: 'favorite',
+    loadChildren: () => import('./favorite/favorite.module').then(m => m.FavoritePageModule)
+  }
 
 ]
 

--- a/src/app/favorite/components/favorite-button.component.ts
+++ b/src/app/favorite/components/favorite-button.component.ts
@@ -1,0 +1,51 @@
+import { Component, Input, OnInit } from '@angular/core'
+import { ToastController } from '@ionic/angular'
+import { FavoriteService } from 'src/app/shared/services/favorite.service'
+
+@Component({
+  selector: 'app-favorite-button',
+  templateUrl: './favorite.component.html',
+  standalone: false
+})
+export class FavoriteButtonComponent implements OnInit {
+  @Input() storeId!: number
+  @Input() userId!: number
+  isFavorite = false
+
+  constructor(private favoriteService: FavoriteService, private toastCtrl: ToastController) {}
+
+  ngOnInit() {
+    this.checkIfFavorite()
+  }
+
+  checkIfFavorite() {
+    this.favoriteService.readFavoritesById(this.userId).subscribe({
+      next: (res) => {
+        this.isFavorite = !!res.data?.find(fav => fav.store_id === this.storeId)
+      },
+    })
+  }
+
+  toggleFavorite() {
+    if (this.isFavorite) {
+      this.favoriteService.deleteFavorite(this.userId, this.storeId).subscribe(() => {
+        this.isFavorite = false
+        this.presentToast('즐겨찾기에서 삭제되었습니다.')
+      })
+    } else {
+      this.favoriteService.createFavorite(this.userId, this.storeId).subscribe(() => {
+        this.isFavorite = true
+        this.presentToast('즐겨찾기에 추가되었습니다.')
+      })
+    }
+  }
+
+  async presentToast(message: string) {
+    const toast = await this.toastCtrl.create({
+      message,
+      duration: 1500,
+      position: 'bottom',
+    })
+    await toast.present()
+  }
+}

--- a/src/app/favorite/components/favorite.component.html
+++ b/src/app/favorite/components/favorite.component.html
@@ -1,0 +1,3 @@
+<ion-button fill="clear" (click)="toggleFavorite()">
+    <ion-icon [name]="isFavorite ? 'heart' : 'heart-outline'" color="danger"></ion-icon>
+</ion-button>

--- a/src/app/favorite/favorite-routing.module.ts
+++ b/src/app/favorite/favorite-routing.module.ts
@@ -1,0 +1,20 @@
+import { NgModule } from '@angular/core'
+import { RouterModule, Routes } from '@angular/router'
+import { FavoritePage } from './pages/favorite.page'
+
+const routes: Routes = [
+  {
+    path: '',
+    component: FavoritePage
+  },
+  {
+    path: ':user_id',
+    component: FavoritePage,
+  },
+]
+
+@NgModule({
+  imports: [RouterModule.forChild(routes)],
+  exports: [RouterModule],
+})
+export class FavoriteRoutingModule {}

--- a/src/app/favorite/favorite.module.ts
+++ b/src/app/favorite/favorite.module.ts
@@ -1,0 +1,16 @@
+import { NgModule } from '@angular/core'
+import { CommonModule } from '@angular/common'
+import { IonicModule } from '@ionic/angular'
+import { FavoritePage } from './pages/favorite.page'
+import { FavoriteRoutingModule } from './favorite-routing.module'
+import { FavoriteButtonComponent } from './components/favorite-button.component'
+
+@NgModule({
+  imports: [
+    CommonModule,
+    IonicModule,
+    FavoriteRoutingModule
+  ],
+  declarations: [FavoritePage, FavoriteButtonComponent]
+})
+export class FavoritePageModule {}

--- a/src/app/favorite/pages/favorite.page.html
+++ b/src/app/favorite/pages/favorite.page.html
@@ -1,0 +1,37 @@
+<ion-header>
+    <ion-toolbar color="primary">
+      <ion-title>즐겨찾기 목록</ion-title>
+    </ion-toolbar>
+  </ion-header>
+  
+  <ion-content>
+    <ion-refresher slot="fixed" (ionRefresh)="loadFavorites($event)">
+      <ion-refresher-content></ion-refresher-content>
+    </ion-refresher>
+  
+    <ion-list>
+      <ion-item-sliding *ngFor="let fav of favorites">
+        <ion-item>
+          <ion-label>
+            <h2>{{ fav.store_name }}</h2>
+          </ion-label>
+  
+          <app-favorite-button
+            [storeId]="fav.store_id"
+            [userId]="user_id"
+            slot="end">
+          </app-favorite-button>
+        </ion-item>
+  
+        <ion-item-options side="end">
+          <ion-item-option color="danger" (click)="removeFavorite(fav.store_id)">
+            삭제
+          </ion-item-option>
+        </ion-item-options>
+      </ion-item-sliding>
+    </ion-list>
+  
+    <ion-text color="medium" *ngIf="favorites.length === 0" class="ion-padding">
+      즐겨찾기에 추가된 상점이 없습니다.
+    </ion-text>
+  </ion-content>

--- a/src/app/favorite/pages/favorite.page.scss
+++ b/src/app/favorite/pages/favorite.page.scss
@@ -1,0 +1,5 @@
+ion-content {
+    ion-list {
+      margin-top: 10px;
+    }
+  }

--- a/src/app/favorite/pages/favorite.page.ts
+++ b/src/app/favorite/pages/favorite.page.ts
@@ -1,0 +1,56 @@
+import { Component, OnInit } from '@angular/core'
+import { ActivatedRoute } from '@angular/router'
+import { FavoriteService } from 'src/app/shared/services/favorite.service'
+
+interface Favorite {
+  store_id: number
+  store_name: string
+}
+
+@Component({
+  selector: 'app-favorites',
+  templateUrl: './favorite.page.html',
+  styleUrls: ['./favorite.page.scss'],
+  standalone: false
+})
+export class FavoritePage implements OnInit {
+  favorites: Favorite[] = []
+
+  constructor(
+    private favoriteService: FavoriteService,
+    private route: ActivatedRoute
+  ) {}
+  
+
+  user_id: number = 0
+
+  ngOnInit() {
+    this.route.paramMap.subscribe(params => {
+        const id = params.get('user_id')
+        if (id) {
+            this.user_id = +id // 문자열을 숫자로 변환
+            console.log(this.user_id)
+            this.loadFavorites()
+        }
+    })
+  }
+
+  loadFavorites(event?: any) {
+
+    this.favoriteService.readFavoritesById(this.user_id).subscribe({
+      next: (res) => {
+        this.favorites = res.data || []
+        if (event) event.target.complete()
+      },
+      error: (error) => {
+        event?.target.complete()
+      },
+    })
+  }
+
+  removeFavorite(store_id: number) {
+    this.favoriteService.deleteFavorite(this.user_id, store_id).subscribe(() => {
+      this.favorites = this.favorites.filter(fav => fav.store_id !== store_id)
+    })
+  }
+}

--- a/src/app/shared/services/favorite.service.ts
+++ b/src/app/shared/services/favorite.service.ts
@@ -1,0 +1,30 @@
+import { HttpClient } from '@angular/common/http'
+import { Injectable } from '@angular/core'
+import { Observable } from 'rxjs'
+import { ApiResponseDTO } from '../model/common/api-response.interface'
+
+interface Favorite {
+    store_id: number
+    store_name: string
+}
+
+@Injectable({
+    providedIn: 'root'
+})
+export class FavoriteService {
+    private apiUrl = 'http://localhost:3000/api/favorites/'
+
+    constructor(private http: HttpClient) { }
+
+    createFavorite(user_id: number, store_id: number): Observable<ApiResponseDTO<void>> {
+        return this.http.post<ApiResponseDTO<void>>(this.apiUrl, { user_id, store_id })
+    }
+
+    readFavoritesById(user_id: number): Observable<ApiResponseDTO<Favorite[]>> {
+        return this.http.get<ApiResponseDTO<Favorite[]>>(`${this.apiUrl}${user_id}`)
+    }
+
+    deleteFavorite(user_id: number, store_id: number): Observable<ApiResponseDTO<void>> {
+        return this.http.request<ApiResponseDTO<void>>('delete', `${this.apiUrl}${user_id}/${store_id}`)
+    }
+}


### PR DESCRIPTION
<!-- 제목은 [태그] #이슈번호 - 작업내용 요약 형식으로 작성해주세요 -->
### Issue
closed #65 
<br/>


## 작업 내용
- `FavoriteService` 구현 (즐겨찾기 추가, 조회, 삭제 API 연동)
- `FavoriteButtonComponent` 생성: 상점 상세 페이지에서 즐겨찾기 버튼 구현 (토글 방식)
- `FavoritesPage` 생성: 사용자의 즐겨찾기 목록 조회 및 삭제 기능 제공
- `favorites.module.ts`, `favorites-routing.module.ts` 별도 구성 (모듈화)
- 메인 라우터(`app-routing.module.ts`)에 즐겨찾기 페이지 라우팅 추가
- Ionic 토스트 메시지로 사용자 액션 피드백 제공 (즐겨찾기 추가 및 삭제 시)


## 체크리스트
- [x] 기능이 정상적으로 동작하는지 확인
- [x] 기존 코드에 영향을 주지 않는지 확인

## 기타 사항
- 참고 자료 (결과물 사진 등)
![image](https://github.com/user-attachments/assets/cf688581-2267-4edd-8dc4-80c88076c734)
우측의 버튼을 누르면 삭제가 가능하다.

![image](https://github.com/user-attachments/assets/dbb6447d-61ea-489d-bc86-a5e4182fac76)
혹시 몰라 슬라이딩도 추가함 (나중에 필요 없으면 지우기)

