### PR TITLE
[feat] #82 - 홈 화면에 지도 미리보기 및 전체 지도 페이지 이동 기능 추가

### DIFF
--- a/src/app/home/home.page.html
+++ b/src/app/home/home.page.html
@@ -13,12 +13,10 @@
     </ion-toolbar>
   </ion-header>
 
-  <div id="container">
-    <strong>용기종기 메인 화면입니다.</strong>
-  </div>
-
-  <div class="image-container" *ngIf="Pika">
-    <img [src]="Pika" alt="Pikachu" class="responsive-img">
+  <!-- 지도 미리보기 -->
+  <div class="mini-map-wrapper" (click)="goToFullMap()">
+    <!-- 미니맵 iframe -->
+    <iframe id="mini-map-iframe" src="assets/naver-map/index.html" width="100%" height="300" style="pointer-events: none; border: none;"></iframe>
   </div>
 
   <ion-button expand="block" (click)="signOut()"> 

--- a/src/app/home/home.page.scss
+++ b/src/app/home/home.page.scss
@@ -25,3 +25,13 @@
 #container a {
   text-decoration: none;
 }
+
+.mini-map-wrapper {
+  position: relative;
+  cursor: pointer;
+  margin-top: 20px;
+  border-radius: 10px;
+  overflow: hidden;
+  box-shadow: 0 2px 6px rgba(0,0,0,0.15);
+}
+

--- a/src/app/home/home.page.ts
+++ b/src/app/home/home.page.ts
@@ -1,7 +1,9 @@
-import { ImagesService } from './../shared/services/images.service';
 import { Component, OnInit } from '@angular/core'
+import { Router } from '@angular/router'
 import { AuthService } from '../shared/services/auth.service'
-import { ActivatedRoute, Router } from '@angular/router'
+import { ImagesService } from './../shared/services/images.service'
+import { MapsService } from '../shared/services/maps.service'
+import { ReadStore } from '../shared/model/stores/read-store.interface'
 
 @Component({
   selector: 'app-home',
@@ -14,12 +16,16 @@ export class HomePage implements OnInit {
   isLoggedIn$ = this.authService.isLoggedIn$
 
   Pika!: string
+  currentLat: number | null = null
+  currentLng: number | null = null
+  stores: ReadStore[] = []
 
   constructor(
     private authService: AuthService,
     private router: Router,
-    private imagesService: ImagesService
-  ) { }
+    private imagesService: ImagesService,
+    private mapsService: MapsService
+  ) {}
 
   async signOut() {
     this.authService.signOut()
@@ -27,10 +33,64 @@ export class HomePage implements OnInit {
   }
 
   ngOnInit() {
+    // 이미지 불러오기
     this.imagesService.getImage('pika.jpg').subscribe((response) => {
-      if (response && response.url) {
+      if (response?.url) {
         this.Pika = response.url
       }
     })
+
+    // 지도 초기화
+    this.initMiniMap()
+  }
+
+  initMiniMap() {
+    if (navigator.geolocation) {
+      navigator.geolocation.getCurrentPosition(
+        (position) => {
+          this.currentLat = position.coords.latitude
+          this.currentLng = position.coords.longitude
+
+          // 현재 위치 기반 주변 가게 조회
+          this.mapsService.readStoreByCurrentLocation(this.currentLat, this.currentLng).subscribe(
+            (stores) => {
+              this.stores = stores
+              this.sendStoresToMiniMap()
+            },
+            (error) => {
+              console.error('주변 가게 정보 불러오기 실패:', error)
+            }
+          )
+        },
+        (error) => {
+          console.error('현재 위치 정보 가져오기 실패:', error)
+        },
+        {
+          enableHighAccuracy: true,
+          timeout: 10000,
+          maximumAge: 0
+        }
+      )
+    } else {
+      console.error('이 브라우저는 위치 정보를 지원하지 않습니다.')
+    }
+  }
+
+  sendStoresToMiniMap() {
+    const iframe = document.getElementById('mini-map-iframe') as HTMLIFrameElement
+    if (iframe?.contentWindow && this.currentLat !== null && this.currentLng !== null) {
+      iframe.contentWindow.postMessage({
+        stores: this.stores,
+        isSearchPerformed: false,
+        currentLocation: {
+          lat: this.currentLat,
+          lng: this.currentLng
+        }
+      }, '*')
+    }
+  }
+
+  goToFullMap() {
+    this.router.navigate(['/map'])
   }
 }


### PR DESCRIPTION
<!-- 제목은 [태그] #이슈번호 - 작업내용 요약 형식으로 작성해주세요 -->
### Issue
closed #82 
<br/>


## 작업 내용
- 미니맵 iframe 추가 (#mini-map-iframe)
- 클릭 이벤트를 위한 래퍼 div 추가
- MapsService를 사용하여 현재 위치 기반 주변 가게 조회
- postMessage를 통해 iframe에 데이터 전달
- goToFullMap() 함수로 전체 지도 페이지(/map) 이동 처리

## 체크리스트
- [x] 기능이 정상적으로 동작하는지 확인
- [x] 기존 코드에 영향을 주지 않는지 확인

## 기타 사항
- 참고 자료 (결과물 사진 등)

![image](https://github.com/user-attachments/assets/0e6bbbd8-6be2-4c6a-935e-a233fc55fbae)

미니 맵을 클릭하면 전체 페이지로 이동한다.

![image](https://github.com/user-attachments/assets/aabb4ef9-8da1-4e1d-b360-f7e09310dbaf)
