### PR TITLE
[feat] #106 - 홈 화면에서 사용자 역할에 따른 이동 버튼 구현

### DIFF
--- a/src/app/home/home.page.html
+++ b/src/app/home/home.page.html
@@ -6,6 +6,23 @@
   </ion-header>
 <app-header-bar></app-header-bar>
 
+<div>
+  <ng-container *ngIf="role === 'MANAGER'">
+    <ion-button expand="block" (click)="goToCreateManagerRequest()">
+      매니저 요청 생성
+    </ion-button>
+    <ion-button expand="block" (click)="goToMyManagerRequests()">
+      내 요청 목록
+    </ion-button>
+  </ng-container>
+
+  <ng-container *ngIf="role === 'ADMIN'">
+    <ion-button expand="block" (click)="goToManagerRequestPage()">
+      매니저 요청 페이지 (관리자용)
+    </ion-button>
+  </ng-container>
+</div>
+
 <!-- <app-search-bar></app-search-bar> -->
 
 <!-- 지도 미리보기 -->

--- a/src/app/home/home.page.ts
+++ b/src/app/home/home.page.ts
@@ -18,6 +18,7 @@ export class HomePage implements OnInit {
   currentLat: number | null = null
   currentLng: number | null = null
   stores: ReadStore[] = []
+  role: string | null = null
 
   constructor(
     private authService: AuthService,
@@ -34,6 +35,7 @@ export class HomePage implements OnInit {
   ngOnInit() {
     // 지도 초기화
     this.initMiniMap()
+    this.role = this.authService.getUserRole()
   }
 
   initMiniMap() {
@@ -85,4 +87,17 @@ export class HomePage implements OnInit {
   goToFullMap() {
     this.router.navigate(['/map'])
   }
+
+  goToCreateManagerRequest() {
+    this.router.navigate(['/manager/create-manager-request'])
+  }
+  
+  goToMyManagerRequests() {
+    this.router.navigate(['/manager/my-manager-requests'])
+  }
+  
+  goToManagerRequestPage() {
+    this.router.navigate(['/admin/manager-request-page'])
+  }
+  
 }

--- a/src/app/shared/services/auth.service.ts
+++ b/src/app/shared/services/auth.service.ts
@@ -48,4 +48,14 @@ export class AuthService {
 
     return payload.nickname || payload.name || null
   }
+
+  getUserRole(): string | null {
+    const token = localStorage.getItem('accessToken')
+    if (!token) return null
+  
+    const payload = parseJwt(token)
+    if (!payload) return null
+  
+    return payload.role || null
+  }
 }


### PR DESCRIPTION
<!-- 제목은 [태그] #이슈번호 - 작업내용 요약 형식으로 작성해주세요 -->
### Issue
closed #106 
<br/>


## 작업 내용
- JWT 토큰에서 사용자 역할(role) 파싱하는 getUserRole() 함수 추가
- manager 계정일 경우 요청 생성/목록 버튼 표시 및 라우팅 연결
- admin 계정일 경우 요청 관리 페이지 버튼 표시 및 라우팅 연결
- 홈 화면에서 역할 기반 조건부 렌더링 적용

## 체크리스트
- [x] 기능이 정상적으로 동작하는지 확인
- [x] 기존 코드에 영향을 주지 않는지 확인

## 기타 사항
- 참고 자료 (결과물 사진 등)
![image](https://github.com/user-attachments/assets/00e57743-fbad-4e94-8724-cc0088f6d9b2)
