### PR TITLE
[feat] #108 - 공통 헤더 컴포넌트 적용

### DIFF
--- a/src/app/admin/pages/admin/admin.page.html
+++ b/src/app/admin/pages/admin/admin.page.html
@@ -1,15 +1,11 @@
 <ion-header [translucent]="true">
+  <app-header-bar></app-header-bar>
   <ion-toolbar>
     <ion-title>dashboard</ion-title>
   </ion-toolbar>
 </ion-header>
 
 <ion-content [fullscreen]="true">
-  <ion-header collapse="condense">
-    <ion-toolbar>
-      <ion-title size="large">admin</ion-title>
-    </ion-toolbar>
-  </ion-header>
 
   <ion-button expand="block" (click)="goManagerRequestsPage()"> 
     점주 신청서

--- a/src/app/admin/pages/manager-request-page/manager-request-page.html
+++ b/src/app/admin/pages/manager-request-page/manager-request-page.html
@@ -1,15 +1,10 @@
 <ion-header [translucent]="true">
+  <app-header-bar></app-header-bar>
   <ion-toolbar>
     <ion-title>dashboard</ion-title>
   </ion-toolbar>
 </ion-header>
 
 <ion-content [fullscreen]="true">
-  <ion-header collapse="condense">
-    <ion-toolbar>
-      <ion-title size="large">admin</ion-title>
-    </ion-toolbar>
-  </ion-header>
-
   <app-request-list></app-request-list>
 </ion-content>

--- a/src/app/manager/manager.module.ts
+++ b/src/app/manager/manager.module.ts
@@ -13,13 +13,15 @@ import { ManagerRequestListComponent } from './components/manager-request-list/m
 import { MyStoresPage } from './pages/my-stores/my-stores.page'
 import { CreateManagerRequestPage } from './pages/create-manager-request/create-manager-request.page'
 import { SearchStoreComponent } from './components/search-store/search-store.component'
+import { SharedModule } from '../shared/module/shared.module'
 
 @NgModule({
   imports: [
     CommonModule,
     FormsModule,
     IonicModule,
-    ManagerRoutingModule
+    ManagerRoutingModule,
+    SharedModule
   ],
   declarations: [
     ManagerPage,

--- a/src/app/manager/pages/create-manager-request/create-manager-request.page.html
+++ b/src/app/manager/pages/create-manager-request/create-manager-request.page.html
@@ -1,3 +1,6 @@
+<ion-header>
+    <app-header-bar></app-header-bar>
+</ion-header>
 <app-search-store style="height: 100%;" (selectedStore)="onStoreSelected($event)"></app-search-store>
 
 <ion-button (click)="submitManagerRequest()">제출하기</ion-button>

--- a/src/app/manager/pages/manager/manager.page.html
+++ b/src/app/manager/pages/manager/manager.page.html
@@ -1,15 +1,11 @@
 <ion-header [translucent]="true">
+  <app-header-bar></app-header-bar>
   <ion-toolbar>
     <ion-title>manager</ion-title>
   </ion-toolbar>
 </ion-header>
 
 <ion-content [fullscreen]="true">
-  <ion-header collapse="condense">
-    <ion-toolbar>
-      <ion-title size="large">manager</ion-title>
-    </ion-toolbar>
-  </ion-header>
 
   <ion-button expand="block" (click)="goMyManagerRequestsPage()"> 
     나의 점주 신청서 

--- a/src/app/manager/pages/my-manager-request/my-manager-requests.page.html
+++ b/src/app/manager/pages/my-manager-request/my-manager-requests.page.html
@@ -1,15 +1,11 @@
 <ion-header [translucent]="true">
+  <app-header-bar></app-header-bar>
   <ion-toolbar>
     <ion-title>나의 점주신청서 목록</ion-title>
   </ion-toolbar>
 </ion-header>
 
 <ion-content [fullscreen]="true">
-  <ion-header collapse="condense">
-    <ion-toolbar>
-      <ion-title size="large">나의 점주신청서 목록</ion-title>
-    </ion-toolbar>
-  </ion-header>
   <ion-button expand="block" (click)="goCreateManagerRequest()">새로운 점주 신청서</ion-button>
   <app-manager-request-list></app-manager-request-list>
 </ion-content>

--- a/src/app/manager/pages/my-stores/my-stores.page.html
+++ b/src/app/manager/pages/my-stores/my-stores.page.html
@@ -1,4 +1,5 @@
 <ion-header>
+  <app-header-bar></app-header-bar>
   <ion-toolbar>
     <ion-title>내 가게 목록</ion-title>
   </ion-toolbar>


### PR DESCRIPTION
<!-- 제목은 [태그] #이슈번호 - 작업내용 요약 형식으로 작성해주세요 -->
### Issue
closed #108 
<br/>


## 작업 내용
- 관리자(admin) 관련 페이지 상단에 공통 헤더 컴포넌트 추가
- 매니저(manager) 관련 페이지 상단에 공통 헤더 컴포넌트 추가
- 기존에 각 페이지마다 중복 정의되어 있던 <ion-header> 및 <ion-title> 제거
- 페이지별로 헤더 UI 일관성 확보

## 체크리스트
- [x] 기능이 정상적으로 동작하는지 확인
- [x] 기존 코드에 영향을 주지 않는지 확인

## 기타 사항
- 리뷰어가 알면 좋을 추가적인 내용
- 참고 자료 (결과물 사진 등)
- 피드백 요청
