### PR TITLE
[feat] #113 - 단일 가게 상세페이지에서 지도 포커스 가게 위치로 변경

### DIFF
--- a/src/app/store/pages/store-detail-page/store-detail-page.ts
+++ b/src/app/store/pages/store-detail-page/store-detail-page.ts
@@ -68,9 +68,10 @@ export class StoreDetailPage implements OnInit {
     iframe.contentWindow.postMessage({
       stores: [this.store],
       isSearchPerformed: false,
-      currentLocation: this.currentLat && this.currentLng
-        ? { lat: this.currentLat, lng: this.currentLng }
-        : undefined
+      // 단일 가게일 경우 현위치를 넘기지 않는다 (현위치가 아닌 가게로 포커스)
+      // currentLocation: this.currentLat && this.currentLng
+      //   ? { lat: this.currentLat, lng: this.currentLng }
+      //   : undefined
     }, '*')
   }
 }

--- a/src/assets/naver-map/script.js
+++ b/src/assets/naver-map/script.js
@@ -143,7 +143,10 @@ function addStoreMarkers(data) {
             }
         })
 
-        mapConfig.map.setCenter(currentPosition)
+        // 단일 store가 아니면 현재 위치로 포커스
+        if (!data.stores || data.stores.length !== 1) {
+            mapConfig.map.setCenter(currentPosition)
+        }
     }
 
     data.stores.forEach(store => {
@@ -209,6 +212,19 @@ function addStoreMarkers(data) {
             mapConfig.activeInfoWindow = infoWindow
         }
     })
+
+    // 모든 마커 생성 후, 단일 가게일 경우 가게로 포커스
+    if (data.stores.length === 1) {
+        const store = data.stores[0]
+        const lat = normalizeCoordinate(store.lat ?? store.latitude, true)
+        const lng = normalizeCoordinate(store.lng ?? store.longitude, false)
+
+        if (lat != null && lng != null && !isNaN(lat) && !isNaN(lng)) {
+            const position = new naver.maps.LatLng(lat, lng)
+            mapConfig.map.setCenter(position)
+            mapConfig.map.setZoom(18)
+        }
+    }
 }
 
 // 마커 초기화


### PR DESCRIPTION
<!-- 제목은 [태그] #이슈번호 - 작업내용 요약 형식으로 작성해주세요 -->
### Issue
closed #113 
<br/>


## 작업 내용
- 단일 가게 상세 페이지에서 지도 포커스가 가게 위치로 잡히도록 수정
- currentLocation이 있더라도 복수 가게가 아닐 경우엔 포커스를 가게로 설정

## 체크리스트
- [x] 기능이 정상적으로 동작하는지 확인
- [x] 기존 코드에 영향을 주지 않는지 확인

## 기타 사항
- 참고 자료 (결과물 사진 등)
![image](https://github.com/user-attachments/assets/287948e9-761e-4dd0-a245-244ca5110e7e)

