### PR TITLE
[fix] #134 - InfoWindow 닫기 버튼 미작동 및 검색창 헤더 가림 현상 수정

### DIFF
--- a/src/app/home/home.page.html
+++ b/src/app/home/home.page.html
@@ -4,7 +4,7 @@
   </ion-toolbar>
 </ion-header>
 
-<ion-content [fullscreen]="true">
+<ion-content [fullscreen]="false">
   <!-- 내부 내용 -->
   <div>
     <ng-container *ngIf="role === 'MANAGER'">

--- a/src/app/map/components/map.component.ts
+++ b/src/app/map/components/map.component.ts
@@ -310,7 +310,18 @@ export class MapComponent implements OnInit, AfterViewInit, OnDestroy {
     this.map.setCenter(position)
     this.map.setZoom(18)
   
-    const marker = new naver.maps.Marker({ position, map: this.map })
+    // 기존 마커, InfoWindow 정리
+    this.markers.forEach(m => m.setMap(null))
+    this.infoWindows.forEach(iw => iw.close())
+    this.markers = []
+    this.infoWindows = []
+  
+    const marker = new naver.maps.Marker({
+      position,
+      map: this.map,
+      title: store.store_name
+    })
+  
     const infoWindow = new naver.maps.InfoWindow({
       content: this.createInfoWindowHtml(store),
       borderWidth: 0,
@@ -318,9 +329,21 @@ export class MapComponent implements OnInit, AfterViewInit, OnDestroy {
       disableAnchor: false,
       disableAutoPan: false
     })
+  
     infoWindow.open(this.map, marker)
     this.markers.push(marker)
-  }  
+    this.infoWindows.push(infoWindow)
+  
+    // InfoWindow 렌더링 이후 닫기 버튼 이벤트 바인딩
+    setTimeout(() => {
+      const closeBtn = document.querySelector('.info-close')
+      if (closeBtn) {
+        closeBtn.addEventListener('click', () => {
+          infoWindow.close()
+        })
+      }
+    }, 0)
+  }
 
   // InfoWindow HTML
   createInfoWindowHtml(store: ReadStore): string {


### PR DESCRIPTION
<!-- 제목은 [태그] #이슈번호 - 작업내용 요약 형식으로 작성해주세요 -->
### Issue
closed #134 
<br/>


## 작업 내용
- InfoWindow 닫기 버튼 미작동 수정
  - infoWindow.open() 직후 DOM이 렌더링되기 전에 document.querySelector('.info-close')가 실행되어 이벤트 바인딩이 되지 않던 문제를 setTimeout으로 해결
  - focusStoreOnMap() 내부에 InfoWindow open 이후 이벤트 바인딩 로직 추가

- Ion header에 검색창 가림 현상 수정
  - home.page.html에서 ion-content의 fullscreen 속성을 false로 설정
  - 지도 상단 콘텐츠가 ion-header에 겹치지 않도록 하여 검색창이 정상적으로 보이도록 함

## 체크리스트
- [x] 기능이 정상적으로 동작하는지 확인
- [x] 기존 코드에 영향을 주지 않는지 확인

## 기타 사항
- 리뷰어가 알면 좋을 추가적인 내용
- 참고 자료 (결과물 사진 등)
- 피드백 요청
