### PR TITLE
[feat] #139 - 개인정보 수정 페이지 구현 및 버그 수정

### DIFF
--- a/src/app/my-page/components/edit-my-info/edit-my-info.component.html
+++ b/src/app/my-page/components/edit-my-info/edit-my-info.component.html
@@ -1,0 +1,39 @@
+<ion-content [fullscreen]="true">
+  <div class="title-bar">
+    <span class="page-title">내 정보 수정</span>
+    <br><br>
+  </div>
+
+  <!-- 이미지 미리보기 -->
+  <div class="preview-image-row" *ngIf="previewUrls.length > 0">
+    <img
+      *ngFor="let url of previewUrls"
+      [src]="url"
+      class="preview-img" />
+  </div>
+
+  <!-- 이미지 업로드 -->
+  <input
+    type="file"
+    accept="image/*"
+    (change)="onFileSelected($event)" />
+
+  <!-- 닉네임 입력창 -->
+  <div class="input-box">
+    <ion-input
+      type="text"
+      placeholder="닉네임"
+      [(ngModel)]="new_nickname"
+      (ngModelChange)="onNicknameChange()">
+    </ion-input>
+  </div>
+
+  <!-- 제출 버튼 -->
+  <app-button
+    label="변경 완료"
+    variant="filled"
+    size="full"
+    [disabled]="isButtonDisabled"
+    (click)="onSubmit()">
+  </app-button>
+</ion-content>

--- a/src/app/my-page/components/edit-my-info/edit-my-info.component.scss
+++ b/src/app/my-page/components/edit-my-info/edit-my-info.component.scss
@@ -1,0 +1,15 @@
+.preview-image-row {
+  display: flex;
+  flex-direction: row;
+  gap: 10px;
+  margin: 10px 0;
+  overflow-x: auto;
+}
+
+.preview-img {
+  width: 60px;
+  height: 60px;
+  object-fit: cover;
+  border-radius: 8px;
+  border: 1px solid #ccc;
+}

--- a/src/app/my-page/components/edit-my-info/edit-my-info.component.ts
+++ b/src/app/my-page/components/edit-my-info/edit-my-info.component.ts
@@ -1,0 +1,93 @@
+import { Component, OnInit } from '@angular/core'
+import { Router } from '@angular/router'
+import { UsersService } from './../../../shared/services/users.service'
+import { ReadUser } from 'src/app/shared/model/users/read-user.interface'
+
+@Component({
+  selector: 'app-edit-my-info',
+  templateUrl: './edit-my-info.component.html',
+  styleUrls: ['./edit-my-info.component.scss'],
+  standalone: false
+})
+export class EditMyInfoComponent implements OnInit {
+  user?: ReadUser
+  new_nickname: string = ''
+  selectedFile?: File
+  original_nickname: string = ''
+  original_image?: string // 기존 이미지 URL (이미지가 있을 경우)
+  previewUrls: string[] = []
+
+  // 버튼 활성화 여부
+  isButtonDisabled: boolean = true
+
+  constructor(
+    private router: Router,
+    private usersService: UsersService
+  ) {
+    const nav = this.router.getCurrentNavigation()
+    this.user = nav?.extras.state?.['user']
+  }
+
+  ngOnInit(): void {
+    if (this.user) {
+      this.new_nickname = this.user.nickname
+      this.original_nickname = this.user.nickname
+      this.original_image = this.user.profile_image.url // 사용자 정보에 프로필 이미지 URL이 있다면 저장
+    }
+  }
+
+  onSubmit() {
+    if (this.isButtonDisabled) return
+
+    const formData = new FormData()
+    formData.append('nickname', this.new_nickname)
+
+    if (this.selectedFile) {
+      formData.append('profile_image', this.selectedFile, this.selectedFile.name)
+    }
+
+    this.usersService.updateUserById(formData).subscribe({
+      next: () => {
+        console.log('User Info Updated Successfully')
+        window.alert('변경이 완료되었습니다.')
+        this.router.navigate(['/my-page'])
+      },
+      error: (err) => {
+        window.alert('변경 실패.')
+        console.log('Failed to Update User Info', err)
+      }
+    })
+  }
+
+  onFileSelected(event: Event): void {
+    const input = event.target as HTMLInputElement
+    if (input.files && input.files.length > 0) {
+      this.selectedFile = input.files[0]
+
+      // 단일 파일만 미리보기 (다중 파일의 경우 반복문 처리)
+      const reader = new FileReader()
+      reader.onload = () => {
+        this.previewUrls = [reader.result as string]  // 배열에 저장
+      }
+      reader.readAsDataURL(this.selectedFile)
+    }
+
+    this.checkIfButtonShouldBeEnabled()
+  }
+
+  onNicknameChange() {
+    // 닉네임이 변경되었을 때 버튼 활성화
+    this.checkIfButtonShouldBeEnabled()
+  }
+
+  checkIfButtonShouldBeEnabled() {
+    if (
+      (this.new_nickname !== this.original_nickname) || // 닉네임이 변경되었을 때
+      (this.selectedFile) // 이미지가 선택되었을 때
+    ) {
+      this.isButtonDisabled = false
+    } else {
+      this.isButtonDisabled = true
+    }
+  }
+}

--- a/src/app/my-page/components/my-info/my-info.component.html
+++ b/src/app/my-page/components/my-info/my-info.component.html
@@ -14,7 +14,7 @@
   <div class="container">
     <div class="sub-title-bar">
       <div class="component-title">나의 정보</div>
-      <app-button label="수정" variant="borderless" size="small"></app-button>
+      <app-button label="수정" variant="borderless" size="small" (click)="goEditMyInfoPage()"></app-button>
     </div>
     <div class="info-table typo-body1">
       <div>

--- a/src/app/my-page/components/my-info/my-info.component.ts
+++ b/src/app/my-page/components/my-info/my-info.component.ts
@@ -1,4 +1,5 @@
 import { Component, OnInit, ViewEncapsulation } from '@angular/core'
+import { ActivatedRoute, Router } from '@angular/router'
 import { ReadUser } from 'src/app/shared/model/users/read-user.interface'
 import { MyPageService } from 'src/app/shared/services/my-page.service'
 
@@ -13,6 +14,8 @@ export class MyInfoComponent implements OnInit {
 
   constructor(
     private myPageService: MyPageService,
+    private route: ActivatedRoute,
+    private router: Router,
   ) { }
 
   ngOnInit() {
@@ -33,4 +36,11 @@ export class MyInfoComponent implements OnInit {
     })
   }
 
+  goEditMyInfoPage() {
+    this.router.navigate([`edit`], {
+      relativeTo: this.route,
+      state: { user: this.user }
+    })
+    console.log('go edit-my-info page')
+  }
 }

--- a/src/app/my-page/my-page-routing.module.ts
+++ b/src/app/my-page/my-page-routing.module.ts
@@ -3,6 +3,7 @@ import { Routes, RouterModule } from '@angular/router'
 
 import { MyPagePage } from './pages/my-page/my-page.page'
 import { MyReviewsPage } from './pages/my-reviews-page/my-reviews.page'
+import { EditMyInfoPagePage } from './pages/edit-my-info-page/edit-my-info-page.page'
 
 const routes: Routes = [
   {
@@ -13,6 +14,10 @@ const routes: Routes = [
     path: 'reviews',
     component: MyReviewsPage
   },
+  {
+    path: 'edit',
+    component: EditMyInfoPagePage
+  }
 ]
 
 @NgModule({

--- a/src/app/my-page/my-page.module.ts
+++ b/src/app/my-page/my-page.module.ts
@@ -12,6 +12,8 @@ import { ReviewsModule } from '../reviews/reviews.module'
 import { MyInfoComponent } from './components/my-info/my-info.component'
 import { MyReviewListComponent } from './components/my-review-list/my-review-list.component'
 import { SharedModule } from '../shared/module/shared.module'
+import { EditMyInfoPagePage } from './pages/edit-my-info-page/edit-my-info-page.page'
+import { EditMyInfoComponent } from './components/edit-my-info/edit-my-info.component'
 
 @NgModule({
   imports: [
@@ -25,8 +27,10 @@ import { SharedModule } from '../shared/module/shared.module'
   declarations: [
     MyPagePage,
     MyReviewsPage,
+    EditMyInfoPagePage,
     MyInfoComponent,
     MyReviewListComponent,
+    EditMyInfoComponent,
   ]
 })
 export class MyPageModule { }

--- a/src/app/my-page/pages/edit-my-info-page/edit-my-info-page.page.html
+++ b/src/app/my-page/pages/edit-my-info-page/edit-my-info-page.page.html
@@ -1,0 +1,10 @@
+<ion-header collapse="condense">
+  <ion-toolbar>
+    <app-header-bar></app-header-bar>
+  </ion-toolbar>
+</ion-header>
+
+<ion-content [fullscreen]="true">
+  <div class="page-title">마이페이지</div>
+  <app-edit-my-info></app-edit-my-info>
+</ion-content>

--- a/src/app/my-page/pages/edit-my-info-page/edit-my-info-page.page.ts
+++ b/src/app/my-page/pages/edit-my-info-page/edit-my-info-page.page.ts
@@ -1,0 +1,15 @@
+import { Component, OnInit } from '@angular/core'
+
+@Component({
+  selector: 'app-edit-my-info-page',
+  templateUrl: './edit-my-info-page.page.html',
+  styleUrls: ['./edit-my-info-page.page.scss'],
+  standalone: false,
+})
+export class EditMyInfoPagePage  implements OnInit {
+
+  constructor() { }
+
+  ngOnInit() {}
+
+}

--- a/src/app/shared/components/loggined/loggined.component.html
+++ b/src/app/shared/components/loggined/loggined.component.html
@@ -4,7 +4,9 @@
   <button *ngIf="isLoggined" (click)="signOut()">Log out</button>
   <button *ngIf="!isLoggined" color="primary" (click)="goSignInPage()">Sign in</button>
 
-  <button color="success" (click)="goMyPage()">
-    <ion-icon name="person-circle-outline"></ion-icon>
+  <!-- 프로필 이미지 버튼 -->
+  <button *ngIf="isLoggined" color="success" (click)="goMyPage()">
+    <img *ngIf="userProfileImage" [src]="userProfileImage" alt="User Profile Image" style="width: 40px; height: 40px; border-radius: 50%;" />
+    <ion-icon *ngIf="!userProfileImage" name="person-circle-outline"></ion-icon>
   </button>
 </div>

--- a/src/app/shared/components/loggined/loggined.component.ts
+++ b/src/app/shared/components/loggined/loggined.component.ts
@@ -1,7 +1,6 @@
 import { Component, OnInit } from '@angular/core'
 import { Router } from '@angular/router'
 import { AuthService } from 'src/app/shared/services/auth.service'
-import { parseJwt } from '../../utils/token.util'
 
 @Component({
   selector: 'app-loggined',
@@ -9,7 +8,7 @@ import { parseJwt } from '../../utils/token.util'
   styleUrls: ['./loggined.component.scss'],
   standalone: false,
 })
-export class LogginedComponent  implements OnInit {
+export class LogginedComponent implements OnInit {
   isLoggined: Boolean = false
   userName: string | null = null
   userProfileImage: string | null = null
@@ -20,13 +19,26 @@ export class LogginedComponent  implements OnInit {
   ) { }
 
   ngOnInit() {
-    this.loadLogginedUserInfo()
+    // 로그인 상태 구독
+    this.authService.isLoggedIn$.subscribe((loggedIn) => {
+      this.isLoggined = loggedIn;
+      if (loggedIn) {
+        this.loadLogginedUserInfo(); // 로그인 정보 로드
+      } else {
+        this.clearUserInfo(); // 로그아웃 시 사용자 정보 초기화
+      }
+    })
+  }
+
+  clearUserInfo() {
+    this.userName = null
+    this.userProfileImage = null
   }
 
   loadLogginedUserInfo() {
     this.userName = this.authService.getLogginedUserName()
     this.userProfileImage = this.authService.getUserProfileImage()
-    if (this.userName) { 
+    if (this.userName) {
       this.isLoggined = true
     }
     console.log('username: ', this.userName)

--- a/src/app/shared/components/loggined/loggined.component.ts
+++ b/src/app/shared/components/loggined/loggined.component.ts
@@ -1,6 +1,7 @@
 import { Component, OnInit } from '@angular/core'
 import { Router } from '@angular/router'
 import { AuthService } from 'src/app/shared/services/auth.service'
+import { parseJwt } from '../../utils/token.util'
 
 @Component({
   selector: 'app-loggined',
@@ -11,6 +12,7 @@ import { AuthService } from 'src/app/shared/services/auth.service'
 export class LogginedComponent  implements OnInit {
   isLoggined: Boolean = false
   userName: string | null = null
+  userProfileImage: string | null = null
 
   constructor(
     private authService: AuthService,
@@ -18,11 +20,12 @@ export class LogginedComponent  implements OnInit {
   ) { }
 
   ngOnInit() {
-    this.loadLogginedUserName()
+    this.loadLogginedUserInfo()
   }
 
-  loadLogginedUserName() {
+  loadLogginedUserInfo() {
     this.userName = this.authService.getLogginedUserName()
+    this.userProfileImage = this.authService.getUserProfileImage()
     if (this.userName) { 
       this.isLoggined = true
     }
@@ -31,7 +34,7 @@ export class LogginedComponent  implements OnInit {
 
   async signOut() {
     this.authService.signOut()
-    await this.router.navigate(['/'])
+    await this.router.navigate(['/signin'])
   }
 
   /* 페이지 이동 */

--- a/src/app/shared/model/users/update-user.interface.ts
+++ b/src/app/shared/model/users/update-user.interface.ts
@@ -1,0 +1,3 @@
+export interface UpdateUser {
+    nickname: string
+}

--- a/src/app/shared/services/auth.service.ts
+++ b/src/app/shared/services/auth.service.ts
@@ -52,10 +52,20 @@ export class AuthService {
   getUserRole(): string | null {
     const token = localStorage.getItem('accessToken')
     if (!token) return null
-  
+
     const payload = parseJwt(token)
     if (!payload) return null
-  
+
     return payload.role || null
+  }
+
+  getUserProfileImage(): string | null {
+    const token = localStorage.getItem('accessToken')
+    if (!token) return null
+
+    const payload = parseJwt(token)
+    if (!payload) return null
+
+    return payload.profile_image || null
   }
 }

--- a/src/app/shared/services/users.service.ts
+++ b/src/app/shared/services/users.service.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@angular/core'
 import { Observable } from 'rxjs'
 import { ApiResponseDTO } from '../model/common/api-response.interface'
-import { HttpClient } from '@angular/common/http'
+import { HttpClient, HttpHeaders } from '@angular/common/http'
 
 @Injectable({
   providedIn: 'root'
@@ -11,8 +11,22 @@ export class UsersService {
 
   constructor(private http: HttpClient) { }
 
+  private getAuthHeaders(): HttpHeaders {
+    const token = localStorage.getItem('accessToken')
+    return new HttpHeaders().set('Authorization', `Bearer ${token ?? ''}`)
+  }
+
   // 이메일 중복 검사
   readEmailExists(email: string): Observable<ApiResponseDTO<boolean>> {
     return this.http.get<ApiResponseDTO<boolean>>(`${this.apiUrl}check-email?email=${email}`)
+  }
+
+  // 유저 정보 변경
+  updateUserById(formdata: FormData): Observable<ApiResponseDTO<void>> {
+    return this.http.put<ApiResponseDTO<void>>(
+      `${this.apiUrl}`,
+      formdata,
+      { headers: this.getAuthHeaders() }
+    )
   }
 }

--- a/src/app/shared/utils/token.util.ts
+++ b/src/app/shared/utils/token.util.ts
@@ -14,10 +14,13 @@ export function getUserIdFromToken(): number | null {
 // 토큰 파싱 유틸 함수
 export function parseJwt(token: string): any | null {
     try {
-      const payload = token.split('.')[1]
-      return JSON.parse(atob(payload))
+        const payloadBase64 = token.split('.')[1];
+        // '+'를 '-'로, '/'를 '_'로 변환하여 Base64 디코딩
+        const base64Url = payloadBase64.replace(/-/g, '+').replace(/_/g, '/');
+        const decodedPayload = atob(base64Url); // Base64 디코딩
+        return JSON.parse(decodedPayload); // JSON으로 변환하여 리턴
     } catch (e) {
-      console.error('Invalid token:', e)
-      return null
+        console.error('Invalid token:', e);
+        return null;
     }
-  }
+}


### PR DESCRIPTION
<!-- 제목은 [태그] #이슈번호 - 작업내용 요약 형식으로 작성해주세요 -->
### Issue
closed #139 
<br/>


## 작업 내용
- 개인정보 수정 페이지 구현 (프로필 사진, 닉네임)
- 헤더바에 사용자 프로필이미지 출력 (마이페이지 버튼)
- 로그아웃 제대로 되게 수정함 (자동으로 로그인 페이지로 이동)
- 다른 사용자로 로그인했음에도, 이전 사용자 정보가 출력되던 버그 수정

## 체크리스트
- [x] 기능이 정상적으로 동작하는지 확인
- [x] 기존 코드에 영향을 주지 않는지 확인

## 기타 사항
- 리뷰어가 알면 좋을 추가적인 내용
- 참고 자료 (결과물 사진 등)
- 피드백 요청
